### PR TITLE
added bug fix for browser cache weirdness

### DIFF
--- a/inc/wpeac-admin.php
+++ b/inc/wpeac-admin.php
@@ -170,7 +170,7 @@ class WPEAC_Admin {
 			<hr>
 			<!-- Add a button to purge specific posts from cache -->
 			<!-- only add the button on a WP ENGINE site -->
-			<?php if ( ! isset( $_SERVER['IS_WPE'] ) ) { ?>
+			<?php if ( isset( $_SERVER['IS_WPE'] ) ) { ?>
 				<table class="form-table">
 					<tr valign="top">
 						<th scope="row">Purge Single Post</th>

--- a/inc/wpeac-admin.php
+++ b/inc/wpeac-admin.php
@@ -170,7 +170,7 @@ class WPEAC_Admin {
 			<hr>
 			<!-- Add a button to purge specific posts from cache -->
 			<!-- only add the button on a WP ENGINE site -->
-			<?php if ( isset( $_SERVER['IS_WPE'] ) ) { ?>
+			<?php if ( ! isset( $_SERVER['IS_WPE'] ) ) { ?>
 				<table class="form-table">
 					<tr valign="top">
 						<th scope="row">Purge Single Post</th>

--- a/inc/wpeac-core.php
+++ b/inc/wpeac-core.php
@@ -209,6 +209,7 @@ class WPEAC_Core {
 	public static function send_header_cache_control_api( $route ) {
 		$namespace = WPEAC_Core::get_namespace( $route );
 		$namespace_cache_length = self::get( $namespace . '_cache_expires_value' );
+		$namespace_cache_length = apply_filters( 'wpe_ac_namespace_cache_length', $namespace_cache_length, $namespace );
 		header( "Cache-Control: max-age=$namespace_cache_length, must-revalidate" );
 	}
 }

--- a/inc/wpeac-core.php
+++ b/inc/wpeac-core.php
@@ -56,9 +56,6 @@ class WPEAC_Core {
 	 * @return last modified headers
 	 */
 	public static function send_header_last_modified( $last_modified, $post_id, $post_type ) {
-		if ( is_user_logged_in() ) {
-			return;
-		}
 		$last_modified_toggle = self::get( 'last_modified_enabled' );
 		//serve last modified headers if they're turned on, or if it's set to only builtins and we're on a builtin
 		if ( '1' == $last_modified_toggle && in_array( $post_type , self::get( 'sanitized_post_types' ) ) ||

--- a/inc/wpeac-core.php
+++ b/inc/wpeac-core.php
@@ -209,7 +209,7 @@ class WPEAC_Core {
 	public static function send_header_cache_control_api( $route ) {
 		$namespace = WPEAC_Core::get_namespace( $route );
 		$namespace_cache_length = self::get( $namespace . '_cache_expires_value' );
-		$namespace_cache_length = apply_filters( 'wpe_ac_namespace_cache_length', $namespace_cache_length, $namespace );
+		$namespace_cache_length = apply_filters( 'wpe_ac_namespace_cache_length', $namespace_cache_length, $namespace, $route );
 		header( "Cache-Control: max-age=$namespace_cache_length, must-revalidate" );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,7 @@ This plugin is a tool that leverages some specific WP Engine tools, as well as g
 == Changelog ==
 
 1.3.1 - Fixed bug with browser caching while user's were logged in
+		Added a filter for the Rest API cache headers
 
 1.3.0 - Added functionality to purge based on URL
 			- Bug fixes for WooCommerce

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ethankennedy, stevenkword
 Tags: wpengine, cache, headers, last-modified
 Requires at least: 3.5
 Tested up to: 4.9
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 
 This plugin is a tool that leverages some specific WP Engine tools, as well as general web options for increasing the cacheability of a WordPress site.
 
@@ -29,6 +29,8 @@ This plugin is a tool that leverages some specific WP Engine tools, as well as g
 4. Configure the cache options for your public post types, and manage other caching related global options.
 
 == Changelog ==
+
+1.3.1 - Fixed bug with browser caching while user's were logged in
 
 1.3.0 - Added functionality to purge based on URL
 			- Bug fixes for WooCommerce

--- a/wpe-advanced-cache.php
+++ b/wpe-advanced-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Engine Advanced Cache Options
  * Plugin URI: https://github.com/EthanKennedy/wpe-advanced-cache
  * Description: This plugin works to increase cache time across the board, and gives a smarter way to purge the cache
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Ethan Kennedy, Steven Word
  * Author URI: http://ethankennedy.me
  * License: GPL2.
@@ -32,6 +32,11 @@ new WPEAC_Core();
  */
 function wpe_ac_add_cache_header() {
 	if ( ! is_singular() ) {
+		return;
+	}
+	// Displaying headers when users were logged in lead to some weird stuff with browser cache.
+	// Better to just avoid it when we're passing through varnish anyway.
+	if ( is_user_logged_in() ) {
 		return;
 	}
 	$post_id = get_the_ID();


### PR DESCRIPTION
A Customer created a chat to address odd behavior while opening posts or pages and then updating them. The max-age header was leading to chrome doing some tactical caching that was causing stale content to be displayed browser side. 

I made it so no headers would come through, since it's not necessary when we're not even interfacing with varnish. 

I also removed the logged in user check from the last-modified header method since it was now redundant. 